### PR TITLE
Feat/send max cut height

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ event: ping
 data: ""
 ```
 
+### Heights
+
+Sent whenever a new cut is fetched from chainweb-node. Client will use this to resume gracefully based on a formula like `$prev_max_height - $confirmation_depth - $max_chain_span`.
+
+Payload is an array of the height of each chain, with implicit indexes (i.e. chain 0 = index 0, etc)
+
+```
+id: 2
+event: heights
+data: [3805145,3805145,3805144,3805145,3805146,3805144,3805146,3805145,3805145,3805146,3805145,3805144,3805145,3805145,3805145,3805145,3805146,3805145,3805146,3805145]
+```
+
 ### Data 
 
 For new or updated data. No event name (default message callback if you are consuming through EventSource).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainweb-sse",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/server.js",
   "type": "module",
   "private": false,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,1 +1,1 @@
-export const WIRE_PROTOCOL_VERSION = "0.0.2";
+export const WIRE_PROTOCOL_VERSION = "0.0.3";

--- a/src/sse/chainweb-event.ts
+++ b/src/sse/chainweb-event.ts
@@ -94,6 +94,9 @@ export default class ChainwebEventService {
     if (!this._cut.running) {
       await this._cut.start();
     }
+    if (!this._cut.lastCut) {
+      await this._cut.hasCut;
+    }
     this.running = true;
     this.logger.verbose(`Started with minHeight=${this._minHeight}`);
     try {

--- a/src/sse/index.ts
+++ b/src/sse/index.ts
@@ -26,6 +26,5 @@ async function notFoundResponse(req, res) {
   res.status(404).send({ error: `Route ${req.url} does not exist` });
 }
 
-
 // RouteService.get('coin')
 // RouteService.route('coin')

--- a/src/sse/types.ts
+++ b/src/sse/types.ts
@@ -51,7 +51,7 @@ export interface InitialEvent {
 
 export interface ChainwebCutData {
   hashes: {
-    [chainId: number]: {
+    [chainId: string]: {
       height: number;
       hash: string;
     }


### PR DESCRIPTION
Implemented a new event `heights`:

- this sends an event `heights` with payload: array of the current cut _as seen on chainweb-node_

- Needed to implement [better resuming](https://github.com/kadena-community/kadena.js/issues/275#issuecomment-1578856960). The corresponding client PR will use this value to resume with better guarantees of event delivery.

Leaving as draft until we are certain about the approach to be taken.